### PR TITLE
Simplify error handling in code

### DIFF
--- a/chat_cli/src/main.rs
+++ b/chat_cli/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Читаем аргументы командной строки.
     let mut cli_args = std::env::args().skip(1);
     let Some(action) = cli_args.next() else {
-        return Err(String::from("No action provided, use 'append' or 'fetch'").into());
+        return Err("No action provided, use 'append' or 'fetch'".into());
     };
 
     println!("Performing action: {action}...");
@@ -24,17 +24,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("{}", chat_history);
         return Ok(());
     }
-    
+
     if action == "append" {
         // Отправляем новое сообщение.
         let Some(msg) = cli_args.next() else {
-            return Err(String::from("No message provided").into());
+            return Err("No message provided".into());
         };
         client.append(&msg)?;
         return Ok(());
     }
-    
-    Err(String::from("Unknown action, use 'append' or 'fetch'").into())
+
+    Err("Unknown action, use 'append' or 'fetch'".into())
 }
 
 fn get_server_addr() -> String {


### PR DESCRIPTION
Dear F3kilo

This pull request aims to simplify the error handling in code by refining the way we return error messages. 

- Replaced the use of String::from("No message provided").into() with a more concise return statement: Err("No message provided".into()).

This change improves code readability and maintainability without altering the functionality.

Please review the changes. Thank you!